### PR TITLE
Skip non buildable projects from the dashboard

### DIFF
--- a/tommy.rb
+++ b/tommy.rb
@@ -23,6 +23,8 @@ class Project < Hashie::Dash
     projects = json['jobs']
     
     projects.each do |project|
+      next if !project['buildable']
+
       returned_projects << Project.new( :name => project['displayName'].gsub('-', ' '),
                                         :build_score => project['healthReport'].first['score'].to_i,
                                         :last_build_number => project['builds'].first['number'],


### PR DESCRIPTION
Non buildable projects should be skipped, to avoid to clutter the
view with templates projects and avoid missing properties errors.

This fixes the following issue:
`undefined method`[]' for nil:NilClass`
