### PR TITLE
Give a CSS class to success builds with < 20 score

### DIFF
--- a/tommy.rb
+++ b/tommy.rb
@@ -65,7 +65,7 @@ helpers do
         "good"
       elsif score >= 40
         "bad"
-      elsif score >= 20
+      else
         "worse"
       end
     elsif project.is_building?


### PR DESCRIPTION
Projects with a success build but a < 20 score didn't receive
any CSS class. This could be the case for some Jenkins jobs
with test coverage metrics.

With this use case, 'worse' seems more indicated than 'worst'
to avoid to flash a card of a success build.
